### PR TITLE
Remove "Code for Canada" and "Code for Toronto" due to inactivity

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -231,17 +231,6 @@
         "type": "Brigade"
     },
     {
-        "name": "Code for Canada",
-        "website": "http://community.codeforcanada.org/",
-        "events_url": "http://www.meetup.com/codeforcanada",
-        "rss": "",
-        "projects_list_url": "https://github.com/codeforcanada",
-        "city": "Canada",
-        "latitude": "43.657398",
-        "longitude": "-79.4328",
-        "type": "Code for All"
-    },
-    {
         "name": "Code for Cary",
         "website": "https://github.com/codeforcary",
         "events_url": "http://www.meetup.com/Triangle-Code-for-America/",
@@ -1065,17 +1054,6 @@
         "latitude": "23.5531",
         "longitude": "121.0211",
         "type": "Brigade, Code for All"
-    },
-    {
-        "name": "Code for Toronto",
-        "website": "http://community.codeforcanada.org/",
-        "events_url": "http://www.meetup.com/codeforcanada",
-        "rss": "",
-        "projects_list_url": "https://github.com/codeforcanada",
-        "city": "Toronto, ON",
-        "latitude": "43.6574",
-        "longitude": "-79.4328",
-        "type": "Brigade"
     },
     {
         "name": "Code for Tucson",


### PR DESCRIPTION
I was in the process of adding Civic Tech Toronto to the Brigade map, and realized that Code for Canada, which is no longer active, is still showing up. Twice in fact :)

Provided that @nvk (the main organizer with whom I used to co-organize) think it appropriate, might we be able to remove these inactive orgs? From what I understand, should they become active again, a new pull request could easily be submitted.

cc: @nvk @alox @gabesawhney
