### PR TITLE
Add California Civic Lab

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -44,6 +44,17 @@
         "type": "Brigade, Official"
     },
     {
+        "name": "California Civic Lab",
+        "website": "http://caciviclab.org/",
+        "events_url": "",
+        "rss": "",
+        "projects_list_url": "https://github.com/caciviclab",
+        "city": "Oakland, CA",
+        "latitude": "37.166111",
+        "longitude": "-119.449444",
+        "type": "Collaboration between Brigades"
+    },
+    {
         "name": "Chi Hack Night",
         "website": "http://chihacknight.org/",
         "events_url": "",


### PR DESCRIPTION
A group of folks convened the CA Civic Lab about a year ago as a collaboration between multiple Brigades: Oakland, San Francisco, and San Diego at least. We have some projects on our github that would be great to add to the cfapi!

Since this is a group not exactly located in any one city, the latitude/longitude is the centroid of California and I just picked city.
