### PR TITLE
Update Code for Newark GitHub URL

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -752,7 +752,7 @@
         "website": "http://www.codefornewark.org/",
         "events_url": "http://www.meetup.com/Code-for-Newark/",
         "rss": "",
-        "projects_list_url": "https://github.com/codefornewark",
+        "projects_list_url": "https://github.com/Code4Newark",
         "city": "Newark, NJ",
         "latitude": "40.7320",
         "longitude": "-74.1742",


### PR DESCRIPTION
Was previously: https://github.com/codefornewark

Which seems to be an abandoned user profile and not our organization profile.

Our new organization profile exists here: https://github.com/Code4Newark
