### PR TITLE
Change project url for OpenSMC

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1786,7 +1786,7 @@
         "website": "http://opensmc.org",
         "events_url": "http://www.meetup.com/opensmc/",
         "rss": "http://opensmc.org/blog/",
-        "projects_list_url": "https://raw.githubusercontent.com/opensmc/project-ideas/master/project-list.json",
+        "projects_list_url": "https://docs.google.com/spreadsheets/d/188H7C7t6RMHL5vOwLJggz2ZeywRwVpFSIzSNApLNc_I/export?format=csv",
         "city": "San Mateo County, CA",
         "latitude": "37.4889",
         "longitude": "-122.2308773",


### PR DESCRIPTION
We're having problems with the CfAPI not picking up updates using the current github-hosted json, so for now we're switching back to the google sheets csv that worked for us before.
