### PR TITLE
Add Open Savannah

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1757,6 +1757,17 @@
         "longitude": "-117.1573",
         "type": "Brigade, Official"
     },
+      {
+        "name": "Open Savannah",
+        "website": "http://opensavannah.org",
+        "events_url": "http://www.meetup.com/opensavannah/",
+        "rss": "",
+        "projects_list_url": "https://github.com/opensavannah",
+        "city": "Savannah, GA",
+        "latitude": "32.0835",
+        "longitude": "-81.0998",
+        "type": "Brigade, Official"
+    },
     {
         "name": "Open Seattle",
         "website": "http://openseattle.org/",


### PR DESCRIPTION
Adding new local brigade for Savannah, GA to `organizations.json`