### PR TITLE
Remove official tags from brigades that are not in salesforce

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -43,7 +43,7 @@
         ]
     },
     {
-        "name": "Beta NYC",
+        "name": "BetaNYC",
         "website": "http://www.beta.nyc",
         "events_url": "http://www.meetup.com/BetaNYC/",
         "rss": "https://beta.nyc/category/blog/rss",

--- a/organizations.json
+++ b/organizations.json
@@ -744,10 +744,9 @@
         "city": "Huntsville, AL",
         "latitude": "34.7014",
         "longitude": "-86.6597",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1411,10 +1410,9 @@
         "city": "Richmond, VA",
         "latitude": "37.5407",
         "longitude": "-77.4336",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1571,10 +1569,9 @@
         "city": "Tallahassee, FL",
         "latitude": "30.4380556",
         "longitude": " -84.2808333",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1688,10 +1685,9 @@
         "city": "Tuscaloosa, AL",
         "latitude": "33.2105",
         "longitude": "-87.5659",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1717,10 +1713,9 @@
         "city": "Las Vegas, NV",
         "latitude": "36.2551",
         "longitude": "-115.2383",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1747,15 +1742,14 @@
         "name": "Code4PuertoRico",
         "website": "http://code4puertorico.org/",
         "events_url": "http://code4puertorico.org/events.html",
-        "rss": "\n",
+        "rss": "",
         "projects_list_url": "https://github.com/Code4PuertoRico",
         "city": "San Juan, PR",
         "latitude": "18.4661",
         "longitude": "-66.1160",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {
@@ -1867,11 +1861,10 @@
         "city": "Grand Rapids, MI",
         "latitude": "42.9634",
         "longitude": "-85.6681",
-        "type": "Brigade, midwest, Official",
+        "type": "Brigade, midwest",
         "tags": [
             "Brigade",
-            "midwest",
-            "Official"
+            "midwest"
         ]
     },
     {
@@ -1918,10 +1911,9 @@
         "city": "South Bend, IN",
         "latitude": "41.6764",
         "longitude": "-86.2520",
-        "type": "Brigade, Official, midwest",
+        "type": "Brigade, midwest",
         "tags": [
             "Brigade",
-            "Official",
             "midwest"
         ]
     },
@@ -2308,10 +2300,9 @@
         "city": "Chattanooga, TN",
         "latitude": "35.0456",
         "longitude": "-85.3097",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official"
+            "Brigade"
         ]
     },
     {


### PR DESCRIPTION
The following brigades are no longer marked as "Active" in Salesforce and should not be marked on the official brigade map:

- Code the South
- Code for RVA
- Code for Tallahassee
- Code for Tuscaloosa
- Code for Vegas
- Code for Puerto Rico
- Friendly Code (Grand Rapids, MI)
- Hack Michiana (South Bend, IN)
- Open Chattanooga