### PR TITLE
Add Uptown.Codes Brigade

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1914,6 +1914,23 @@
         "social_profiles": {}
     },
     {
+        "name": "Uptown.Codes",
+        "website": "http://uptown.codes/",
+        "city": "Chicago, IL",
+        "latitude": "41.8755546",
+        "longitude": "-87.6244212",
+        "events_url": "https://www.meetup.com/Code-and-Coffee-Uptown-Brigade/",
+        "projects_list_url": "https://github.com/Code-and-Coffee-Uptown-Brigade",
+        "tags": [
+            "Official",
+            "Brigade",
+            "Code for America"
+        ],
+        "social_profiles": {
+            "twitter": "@codeuptown"
+        }
+    },
+    {
         "name": "g0v.tw",
         "website": "http://g0v.tw/",
         "events_url": "",


### PR DESCRIPTION
Welcome to the Brigade family, Uptown.Codes! @csethna and @ryan-koch - This repo contains information about brigades that is exposed via the [Code for America API](https://api.codeforamerica.org) and the [official Brigade website](https://brigade.codeforamerica.org).

This will get you on the map, and your very own brigade page on the CfA brigade website!

Feel free to update this entry at any point down the road by submitting a pull request to this repo. (Updates will take up to 24 hours to propagate.)