### PR TITLE
Remove "Official" "Code for America" from non-MOU brigades

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -674,13 +674,15 @@
         "city": "Greensboro, NC",
         "latitude": "36.0690",
         "longitude": "-79.7947",
-        "type": "Brigade",
+        "type": "Brigade, Official",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforgreensboro/",
             "twitter": "@CodeForGSO"
         },
         "tags": [
-            "Brigade"
+            "Brigade",
+            "Official",
+            "Code for America"
         ]
     },
     {
@@ -876,14 +878,16 @@
         "city": "Kansas City, KS & MO",
         "latitude": "39.1030",
         "longitude": "-94.5831",
-        "type": "Brigade, midwest",
+        "type": "Brigade, midwest, Official",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforkc",
             "twitter": "@codeforkc"
         },
         "tags": [
             "Brigade",
-            "midwest"
+            "Code for America",
+            "midwest",
+            "Official"
         ]
     },
     {
@@ -1209,13 +1213,15 @@
         "city": "Newark, NJ",
         "latitude": "40.7320",
         "longitude": "-74.1742",
-        "type": "Brigade",
+        "type": "Brigade, Official",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codefornewark/",
             "twitter": "@codefornewark"
         },
         "tags": [
-            "Brigade"
+            "Brigade",
+            "Official",
+            "Code for America"
         ]
     },
     {
@@ -1878,10 +1884,11 @@
         "events_url": "",
         "projects_list_url": "",
         "tags": [
-            "Brigade"
+            "Official",
+            "Brigade",
+            "Code for America"
         ],
-        "social_profiles": {},
-        "type": "Brigade"
+        "social_profiles": {}
     },
     {
         "name": "Uptown.Codes",
@@ -2299,13 +2306,15 @@
         "city": "Austin, TX",
         "latitude": "30.2672",
         "longitude": "-97.7431",
-        "type": "Brigade",
+        "type": "Brigade, Official",
         "social_profiles": {
             "facebook": "https://www.facebook.com/openatx/",
             "twitter": "@openaustin"
         },
         "tags": [
-            "Brigade"
+            "Brigade",
+            "Official",
+            "Code for America"
         ]
     },
     {
@@ -3016,14 +3025,16 @@
         "events_url": "https://www.meetup.com/sketchcity/",
         "projects_list_url": "https://github.com/sketch-city",
         "city": "Houston, TX",
-        "type": "Brigade",
+        "type": "Brigade, Official",
         "latitude": "29.7604267",
         "longitude": "-95.3698028",
         "social_profiles": {
             "facebook": "https://www.facebook.com/groups/openhoustongov/"
         },
         "tags": [
-            "Brigade"
+            "Brigade",
+            "Official",
+            "Code for America"
         ]
     },
     {

--- a/organizations.json
+++ b/organizations.json
@@ -1309,13 +1309,15 @@
         "city": "Philadelphia, PA",
         "latitude": "39.9523",
         "longitude": "-75.1638",
-        "type": "Brigade",
+        "type": "Brigade, Official",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforphilly/",
             "twitter": "@codeforphilly"
         },
         "tags": [
-            "Brigade"
+            "Brigade",
+            "Official",
+            "Code for America"
         ]
     },
     {

--- a/organizations.json
+++ b/organizations.json
@@ -81,11 +81,9 @@
         "city": "Chicago, IL",
         "latitude": "41.8781",
         "longitude": "-87.6298",
-        "type": "Brigade, midwest, Official",
+        "type": "Brigade, midwest",
         "tags": [
             "Brigade",
-            "Official",
-            "Code for America",
             "midwest"
         ]
     },
@@ -141,14 +139,12 @@
         "city": "Albuquerque, NM",
         "latitude": "35.0824",
         "longitude": "-106.6765",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@codeforabq"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -278,14 +274,12 @@
         "city": "Birmingham, AL",
         "latitude": "33.5207",
         "longitude": "-86.8118",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/Codeforbirmingham"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -317,14 +311,12 @@
         "city": "Boulder, CO",
         "latitude": "40.0176",
         "longitude": "-105.2797",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@CodeforBoulder"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -623,14 +615,12 @@
         "city": "Gainesville, FL",
         "latitude": "29.651634",
         "longitude": "-82.324826",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@c4gnv"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -684,15 +674,13 @@
         "city": "Greensboro, NC",
         "latitude": "36.0690",
         "longitude": "-79.7947",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforgreensboro/",
             "twitter": "@CodeForGSO"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -759,11 +747,10 @@
         "events_url": "",
         "projects_list_url": "",
         "tags": [
-            "Official",
-            "Brigade",
-            "Code for America"
+            "Brigade"
         ],
-        "social_profiles": {}
+        "social_profiles": {},
+        "type": "Brigade"
     },
     {
         "name": "Code the South",
@@ -889,16 +876,14 @@
         "city": "Kansas City, KS & MO",
         "latitude": "39.1030",
         "longitude": "-94.5831",
-        "type": "Brigade, midwest, Official",
+        "type": "Brigade, midwest",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforkc",
             "twitter": "@codeforkc"
         },
         "tags": [
             "Brigade",
-            "Code for America",
-            "midwest",
-            "Official"
+            "midwest"
         ]
     },
     {
@@ -1153,14 +1138,12 @@
         "city": "Nashville, TN",
         "latitude": "36.1678",
         "longitude": "-86.7782",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@code4nashville"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1172,11 +1155,9 @@
         "city": "Manchester, NH",
         "latitude": "43.008663",
         "longitude": "-71.454391",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1228,15 +1209,13 @@
         "city": "Newark, NJ",
         "latitude": "40.7320",
         "longitude": "-74.1742",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codefornewark/",
             "twitter": "@codefornewark"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1330,15 +1309,13 @@
         "city": "Philadelphia, PA",
         "latitude": "39.9523",
         "longitude": "-75.1638",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeforphilly/",
             "twitter": "@codeforphilly"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1470,15 +1447,13 @@
         "city": "Sacramento, CA",
         "latitude": "38.5816",
         "longitude": "-121.4944",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/code4sac/",
             "twitter": "@code4sac"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1629,15 +1604,13 @@
         "city": "Tampa, FL",
         "latitude": "27.9465",
         "longitude": "-82.4593",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/CodeforTampaBay",
             "twitter": "@CodeForTampaBay"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1692,14 +1665,12 @@
         "city": "Tucson, AZ",
         "latitude": "32.2216",
         "longitude": "-110.9698",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@CodeforTucson"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1773,15 +1744,13 @@
         "city": "Rhode Island",
         "latitude": "41.4887",
         "longitude": "-71.4543",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/codeislandbrigade",
             "twitter": "@code_island"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1907,11 +1876,10 @@
         "events_url": "",
         "projects_list_url": "",
         "tags": [
-            "Official",
-            "Brigade",
-            "Code for America"
+            "Brigade"
         ],
-        "social_profiles": {}
+        "social_profiles": {},
+        "type": "Brigade"
     },
     {
         "name": "Uptown.Codes",
@@ -2329,15 +2297,13 @@
         "city": "Austin, TX",
         "latitude": "30.2672",
         "longitude": "-97.7431",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/openatx/",
             "twitter": "@openaustin"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2460,14 +2426,12 @@
         "city": "Indianapolis, IN",
         "latitude": "39.7669",
         "longitude": "-86.1500",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@IndyBrigade"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2626,16 +2590,14 @@
         "city": "Seattle, WA",
         "latitude": "47.6062",
         "longitude": "-122.3321",
-        "type": "Brigade, Official",
+        "type": "Brigade, South",
         "social_profiles": {
             "facebook": "https://www.facebook.com/openseattle/",
             "twitter": "@open_seattle"
         },
         "tags": [
             "Brigade",
-            "Official",
-            "South",
-            "Code for America"
+            "South"
         ]
     },
     {
@@ -2682,15 +2644,13 @@
         "city": "Wichita, KS",
         "latitude": "37.6870",
         "longitude": "-97.3356",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/openwichita/",
             "twitter": "@openwichita"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2933,7 +2893,7 @@
         "events_url": "https://www.meetup.com/Code-for-Fort-Collins/",
         "projects_list_url": "https://github.com/codeforfoco",
         "city": "Fort Collins, CO",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "40.5852602",
         "longitude": "-105.084423",
         "social_profiles": {
@@ -2941,9 +2901,7 @@
             "twitter": "@codeforfoco"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2968,7 +2926,7 @@
         "events_url": "https://www.meetup.com/Code-for-OKC/",
         "projects_list_url": "github.com/codeforokc",
         "city": "Oklahoma City, OK",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "35.4675602",
         "longitude": "-97.5164276",
         "social_profiles": {
@@ -2976,9 +2934,7 @@
             "twitter": "@codeforokc"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -3005,7 +2961,7 @@
         "events_url": "https://www.meetup.com/codeforprinceton/",
         "projects_list_url": "github.com/codeforprinceton",
         "city": "Princeton, NJ",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "40.3572976",
         "longitude": "-74.6672226",
         "social_profiles": {
@@ -3013,9 +2969,7 @@
             "twitter": "@codeprinceton"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -3043,7 +2997,7 @@
         "events_url": "",
         "projects_list_url": "https://github.com/OpenDenton",
         "city": "Denton, TX",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "33.2148412",
         "longitude": "-97.13306829999999",
         "social_profiles": {
@@ -3051,9 +3005,7 @@
             "twitter": "@opendenton"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -3062,16 +3014,14 @@
         "events_url": "https://www.meetup.com/sketchcity/",
         "projects_list_url": "https://github.com/sketch-city",
         "city": "Houston, TX",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "29.7604267",
         "longitude": "-95.3698028",
         "social_profiles": {
             "facebook": "https://www.facebook.com/groups/openhoustongov/"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -3087,9 +3037,7 @@
             "Google": "https://groups.google.com/a/bloomington.in.gov/forum/#!forum/civic-hacking"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {


### PR DESCRIPTION
If these Brigades sign the MOU, then they'll get re-added here.

* Chi Hack Night
* Code for ABQ
* Code for Birmingham
* BMG Hack
* Code for Boulder
* Code for Fort Collins
* Code for Gainesville
* Code for Kansas City
* Code for Nashville
* Code for Princeton
* Code for RGV (Rio Grande Valley)
* Code for Sacramento
* Code for Tampa Bay
* Code for Tucson
* Code Island
* Open Denton
* Open Indy
* Open Seattle
* Open Wichita