### PR TITLE
Remove Code for Raleigh project list URL

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1407,7 +1407,7 @@
         "website": "http://www.codeforraleigh.com/",
         "events_url": "http://www.meetup.com/Triangle-Code-for-America/",
         "rss": "",
-        "projects_list_url": "https://github.com/codeforraleigh",
+        "projects_list_url": "",
         "city": "Raleigh, NC",
         "latitude": "35.7721",
         "longitude": "-78.6386",


### PR DESCRIPTION
The Github profile doesn't exist.