### PR TITLE
Update Code Island's city to Providence, RI

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1761,7 +1761,7 @@
         "events_url": "http://www.meetup.com/Rhode-Island-Code-for-America-Brigade/",
         "rss": "",
         "projects_list_url": "https://github.com/codeisland",
-        "city": "Rhode Island",
+        "city": "Providence, RI",
         "latitude": "41.4887",
         "longitude": "-71.4543",
         "type": "Brigade, Official, Code for America",


### PR DESCRIPTION
According to their website, they meet in Providence, RI.

This makes sure that Code Island's city uses the same `City, State Abbreviation (e.g. San Francisco, CA)` convention used for other brigades.