### PR TITLE
Add `previous_names` to JSON and two brigades

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,24 @@ A single organization's record looks like this:
 }
 ```
 
-* `name` - Required - The name of your organization. 
-* `events_url` is the URL of your event-scheduling page. Only **meetup.com** URLs are supported.
-* `rss` is the URL of a blog or its RSS feed. The API will look in the usual places for a feed URL if the link isn't direct. Non-blog RSS feeds will also be processed.
-* `projects_list_url` is the URL of a GitHub organization or of a list of project URLs, formatted as [described below](https://github.com/codeforamerica/brigade-information#projects-list).
-* `latitude` and `longitude` values can be figured out using a tool like [LatLong.net](http://www.latlong.net/). Required if you want to appear on the [Brigade](http://www.codeforamerica.org/brigade/) or [Code for All](http://codeforall.org/) maps.
-* `tags` is an array of descriptors for your group.
-  The most commonly used tags are:
+### Official Schema
+
+* **`name`** (Required) - The name of your organization.
+* **`events_url`** - The URL of your event-scheduling page. Only **meetup.com** URLs are supported.
+* **`rss`** - The URL of a blog or its RSS feed. The API will look in the usual places for a feed URL if the link isn't direct. Non-blog RSS feeds will also be processed.
+* **`previous_names`** - An array of former names of the organization. This can be useful in maintaining URL redirects or noticing which Brigades have changed names over time.
+* **`projects_list_url`** - The URL of a GitHub organization or of a list of project URLs, formatted as [described below](https://github.com/codeforamerica/brigade-information#projects-list).
+* **`latitude`** / **`longitude`** - Where your Brigade meets. It can be as specific or general as you want, and can be figured out using a tool like [LatLong.net](http://www.latlong.net/). Required if you want to appear on the [Brigade](http://www.codeforamerica.org/brigade/) or [Code for All](http://codeforall.org/) maps.
+* **`tags`** - An array of descriptors for your group.
+  Some commonly used tags are:
   * `Brigade`
   * `Official`
-  * `Code for All` - CodeForAll.org network member
-  * `Code for All Affiliate` - Code for All network affiliate member
-  * `Fellowship` - organization is running a fellowship program 
+  * `Code for All` - Code for All network member ("Governing Partner")
+  * `Code for All Affiliate` - Code for All network Affiliate Partner
+  * `Fellowship` - organization is running a fellowship program
   * `Government`
-* `type` (DEPRECATED) is a list of tags, comma separated. Use `tags` instead.
-* `social_profiles` is an object with the keys being the name of the social network and the value being the identifying address on that network. Specifically,
+* **`type`** (DEPRECATED) is a list of tags, comma separated. Use `tags` instead.
+* **`social_profiles`** is an object with the keys being the name of the social network and the value being the identifying address on that network. Specifically,
   * `twitter` - The Twitter handle including `@`.
   * `facebook` - The Facebook Page URL
 

--- a/organizations.json
+++ b/organizations.json
@@ -296,12 +296,16 @@
         ]
     },
     {
-        "name": "Code for Bloomington (BMG Hack)",
+        "name": "Code for Bloomington",
         "website": "https://bmghack.github.io/",
         "city": "Bloomington, IN",
         "latitude": "39.1670396",
         "longitude": "-86.5342881",
-        "events_url": "",
+        "events_url": "https://www.meetup.com/Code-for-Bloomington-BMG-Hack/",
+        "previous_names": [
+          "Code for Bloomington (BMG Hack)",
+          "BMG Hack"
+        ],
         "projects_list_url": "https://github.com/BMGhack/civic-hacking",
         "tags": [
             "Official",
@@ -310,7 +314,8 @@
         ],
         "social_profiles": {
             "Google": "https://groups.google.com/a/bloomington.in.gov/forum/#!forum/civic-hacking"
-        }
+        },
+        "type": "Brigade"
     },
     {
         "name": "Code for Boston",
@@ -2019,12 +2024,14 @@
         "latitude": "41.9294736",
         "longitude": "-88.7503647",
         "events_url": "",
+        "previous_names": [
+          "Tech Bark"
+        ],
         "projects_list_url": "",
         "tags": [
-            "Official",
-            "Brigade",
-            "Code for America"
-        ]
+            "Brigade"
+        ],
+        "type": "Brigade"
     },
     {
         "name": "Open Toledo",

--- a/organizations.json
+++ b/organizations.json
@@ -303,8 +303,8 @@
         "longitude": "-86.5342881",
         "events_url": "https://www.meetup.com/Code-for-Bloomington-BMG-Hack/",
         "previous_names": [
-          "Code for Bloomington (BMG Hack)",
-          "BMG Hack"
+            "Code for Bloomington (BMG Hack)",
+            "BMG Hack"
         ],
         "projects_list_url": "https://github.com/BMGhack/civic-hacking",
         "tags": [
@@ -2025,7 +2025,7 @@
         "longitude": "-88.7503647",
         "events_url": "",
         "previous_names": [
-          "Tech Bark"
+            "Tech Bark"
         ],
         "projects_list_url": "",
         "tags": [


### PR DESCRIPTION
There are a couple Brigades that have had inconsistent names across
different data sources. In order to support a data standardization
use-case and also to support Brigades changing name over time, let's add
an array of `previous_names` that can be used to get a bit of history
for Brigades. We will be using this on the CfA brigade website to
generate redirects for old Brigade pages.