### PR TITLE
Update CfA Brigades based on MOU status

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ A single organization's record looks like this:
   Some commonly used tags are:
   * `Brigade`
   * `Official`
+  * `Code for America` - Code for America Brigade
+  * `Code for America Partner Brigade` - A separate 501(c)3 nonprofit that is an official Code for America Brigade.
+  * `Code for America Fiscally Sponsored Brigade` - A Brigade that uses a non-Code for America Fiscal Sponsor.
   * `Code for All` - Code for All network member ("Governing Partner")
   * `Code for All Affiliate` - Code for All network Affiliate Partner
   * `Fellowship` - organization is running a fellowship program

--- a/bin/merge-from-salesforce
+++ b/bin/merge-from-salesforce
@@ -23,7 +23,8 @@ def are_urls_equal(url, other):
 def is_official_brigade(brigade):
     return 'tags' in brigade and \
             'Brigade' in brigade['tags'] and \
-            'Official' in brigade['tags']
+            'Official' in brigade['tags'] and \
+            'Code for America' in brigade['tags']
 
 
 def load_organizations(filename):
@@ -76,32 +77,16 @@ def find_renamed_brigades(missing_brigades, extra_brigades):
     # set containing tuples of (old name, new name)
     renamed_brigades = set()
 
-    # dict of { "website" => [old name, new name] }
-    matches_by_website = { missing['Website']: [
-        missing['Account Name'],
-        next(iter([extra['name'] for extra in extra_brigades if are_urls_equal(extra['website'], missing['Website'])]), None)] for missing in missing_brigades
-    }
-    for (_, (new_brigade_name, old_brigade_name)) in matches_by_website.items():
-        if old_brigade_name and new_brigade_name:
-            renamed_brigades.add((old_brigade_name, new_brigade_name))
+    for missing in missing_brigades:
+        for extra in extra_brigades:
+            if missing['Website'] and are_urls_equal(missing['Website'], extra['website']):
+                renamed_brigades.add((extra['name'], missing['Account Name']))
 
-    # if the Meetup Link is the same, assume the brigade is too
-    matches_by_meetup = { missing['MeetUp Link']: [
-        missing['Account Name'],
-        next(iter([extra['name'] for extra in extra_brigades if are_urls_equal(extra['events_url'], missing['MeetUp Link'])]), None)] for missing in missing_brigades
-    }
-    for (_, (new_brigade_name, old_brigade_name)) in matches_by_meetup.items():
-        if old_brigade_name and new_brigade_name:
-            renamed_brigades.add((old_brigade_name, new_brigade_name))
+            if missing['MeetUp Link'] and are_urls_equal(missing['MeetUp Link'], extra['events_url']):
+                renamed_brigades.add((extra['name'], missing['Account Name']))
 
-    # if the Github Link is the same, assume the brigade is too
-    matches_by_github = { missing['Github URL']: [
-        missing['Account Name'],
-        next(iter([extra['name'] for extra in extra_brigades if are_urls_equal(extra['projects_list_url'], missing['Github URL'])]), None)] for missing in missing_brigades
-    }
-    for (_, (new_brigade_name, old_brigade_name)) in matches_by_github.items():
-        if old_brigade_name and new_brigade_name:
-            renamed_brigades.add((old_brigade_name, new_brigade_name))
+            if missing['Github URL'] and are_urls_equal(missing['Github URL'], extra['projects_list_url']):
+                renamed_brigades.add((extra['name'], missing['Account Name']))
 
     return list(renamed_brigades)
 
@@ -114,6 +99,10 @@ def remove_brigade(brigade_name, existing, full_removal=False):
         else:
             existing[remove_idx]['tags'].remove('Official')
             existing[remove_idx]['tags'].remove('Code for America')
+            if 'Code for America Partner Brigade' in existing[remove_idx]['tags']:
+                existing[remove_idx]['tags'].remove('Code for America Partner Brigade')
+            if 'Code for America Fiscally Sponsored Brigade' in existing[remove_idx]['tags']:
+                existing[remove_idx]['tags'].remove('Code for America Fiscally Sponsored Brigade')
             existing[remove_idx]['type'] = ", ".join(existing[remove_idx]['tags'])
     except StopIteration:
         print "Could not remove brigade {}".format(brigade_name)
@@ -166,10 +155,15 @@ def rename_brigade(old_brigade_name, new_brigade_name, existing, salesforce):
             projects_list_url=new_brigade['Github URL'],
             previous_names=previous_names)
 
-def mark_brigade_official(brigade_name, existing):
+def mark_brigade_official(salesforce_brigade, existing):
+    brigade_name = salesforce_brigade['Account Name']
     brigade_idx = next(i for i, b in enumerate(existing) if brigade_name == b['name'])
     existing[brigade_idx]['tags'].append('Official')
     existing[brigade_idx]['tags'].append('Code for America')
+    if salesforce_brigade['Brigade Type'] == 'Fiscally Sponsored Brigade':
+        existing[brigade_idx]['tags'].append('Code for America Fiscally Sponsored Brigade')
+    if salesforce_brigade['Brigade Type'] == 'Partner':
+        existing[brigade_idx]['tags'].append('Code for America Partner Brigade')
     existing[brigade_idx]['type'] = ", ".join(existing[brigade_idx]['tags'])
     assert is_official_brigade(existing[brigade_idx])
 
@@ -185,15 +179,14 @@ if __name__ == '__main__':
     existing = load_organizations(organizations_json_path)
     salesforce = load_report(salesforce_path)
 
-    print "Newly Official Brigades:"
-    for newly_official_brigade in find_newly_official_brigades(existing, salesforce):
-        print newly_official_brigade['name']
-        mark_brigade_official(newly_official_brigade['name'], existing)
-
     # Find possibly-missing and possibly-extra brigades, since typically a
     # Brigade rename will appear as a deletion and addition.
     missing_brigades = find_missing_brigades(existing, salesforce)
+    print "Found {} Missing Brigades:".format(len(missing_brigades))
+    print ", ".join([b['Account Name'] for b in missing_brigades])
     extra_brigades = find_extra_brigades(existing, salesforce)
+    print "Found {} Extra Brigades:".format(len(extra_brigades))
+    print ", ".join([b['name'] for b in extra_brigades])
 
     print ""
     print "Renamed Brigades:"
@@ -204,9 +197,15 @@ if __name__ == '__main__':
         del extra_brigades[next(i for i, b in enumerate(extra_brigades) if old_brigade_name == b['name'])]
 
     print ""
-    print "Missing Brigades (from JSON):"
+    print "Newly Official Brigades:"
+    for newly_official_brigade in find_newly_official_brigades(existing, salesforce):
+        print newly_official_brigade['name']
+        mark_brigade_official(newly_official_brigade, existing)
+
+    print ""
+    print "Missing Brigades to Add:"
     for missing_brigade in missing_brigades:
-        print missing_brigade['name']
+        print missing_brigade['Account Name']
         add_brigade(existing, name=missing_brigade['Account Name'],
                 events_url=missing_brigade['MeetUp Link'],
                 city=missing_brigade['Brigade Location'],
@@ -216,9 +215,9 @@ if __name__ == '__main__':
                 projects_list_url=missing_brigade['Github URL'])
 
     print ''
-    print "Extra Brigades (in JSON):"
+    print "Extra Brigades To Remove:"
     for extra_brigade in extra_brigades:
-        print extra_brigade
+        print extra_brigade['name']
         remove_brigade(extra_brigade['name'], existing)
 
     dump_organizations(existing, organizations_json_path)

--- a/organizations.json
+++ b/organizations.json
@@ -464,6 +464,22 @@
         "rss": "https://google.com/alerts/feeds/06912685966400056337/1444738145735582281"
     },
     {
+        "name": "Code for Hackensack",
+        "website": "",
+        "city": "Hackensack, NJ",
+        "latitude": "40.8859326",
+        "longitude": "-74.0434736",
+        "events_url": "https://www.meetup.com/Code-for-Hackensack/",
+        "previous_names": [],
+        "projects_list_url": "",
+        "tags": [
+            "Official",
+            "Brigade",
+            "Code for America"
+        ],
+        "social_profiles": {}
+    },
+    {
         "name": "Code for Iowa",
         "website": "",
         "city": "Iowa City, IA",
@@ -480,6 +496,22 @@
         "rss": "https://google.com/alerts/feeds/06912685966400056337/7301583704927492620"
     },
     {
+        "name": "Code for Kentuckiana",
+        "website": "",
+        "city": "Louisville, KY",
+        "latitude": "38.2542376",
+        "longitude": "-85.759407",
+        "events_url": "",
+        "previous_names": [],
+        "projects_list_url": "",
+        "tags": [
+            "Official",
+            "Brigade",
+            "Code for America"
+        ],
+        "social_profiles": {}
+    },
+    {
         "name": "Code for Kissimmee",
         "website": "",
         "city": "Kissimmee, FL",
@@ -488,12 +520,11 @@
         "events_url": "https://www.meetup.com/Code-for-Kissimmee/",
         "projects_list_url": "",
         "tags": [
-            "Official",
-            "Brigade",
-            "Code for America"
+            "Brigade"
         ],
         "social_profiles": {},
-        "rss": "https://google.com/alerts/feeds/06912685966400056337/7566160790037972973"
+        "rss": "https://google.com/alerts/feeds/06912685966400056337/7566160790037972973",
+        "type": "Brigade"
     },
     {
         "name": "Code for Puerto Rico",
@@ -548,6 +579,27 @@
             "facebook": "https://www.facebook.com/opensaltlakeutah/"
         },
         "rss": "https://google.com/alerts/feeds/06912685966400056337/7566160790037974453"
+    },
+    {
+        "name": "KC Digital Drive",
+        "website": "http://codeforokc.org/",
+        "city": "Kansas City, MO",
+        "latitude": "39.100105",
+        "longitude": "-94.5781416",
+        "events_url": "https://www.meetup.com/KCBrigade/",
+        "previous_names": [
+            "Code for Kansas City"
+        ],
+        "projects_list_url": "https://github.com/codeforkansascity",
+        "tags": [
+            "Official",
+            "Brigade",
+            "Code for America"
+        ],
+        "social_profiles": {
+            "twitter": "@codeforkc",
+            "facebook": "https://www.facebook.com/codeforkc"
+        }
     },
     {
         "name": "Open Charlotte Brigade",
@@ -894,12 +946,11 @@
         "events_url": "https://www.meetup.com/Code-for-Homestead/",
         "projects_list_url": "",
         "tags": [
-            "Official",
-            "Brigade",
-            "Code for America"
+            "Brigade"
         ],
         "social_profiles": {},
-        "rss": "https://google.com/alerts/feeds/06912685966400056337/1444738145735585158"
+        "rss": "https://google.com/alerts/feeds/06912685966400056337/1444738145735585158",
+        "type": "Brigade"
     },
     {
         "name": "Code for Muskogee",
@@ -1058,27 +1109,6 @@
         "type": "Brigade",
         "tags": [
             "Brigade"
-        ]
-    },
-    {
-        "name": "Code for Kansas City",
-        "website": "http://codeforkc.org/",
-        "events_url": "https://www.meetup.com/KCBrigade/",
-        "rss": "https://google.com/alerts/feeds/06912685966400056337/15266640778775467391",
-        "projects_list_url": "https://github.com/codeforkansascity",
-        "city": "Kansas City, KS & MO",
-        "latitude": "39.1030",
-        "longitude": "-94.5831",
-        "type": "Brigade, midwest, Official",
-        "social_profiles": {
-            "facebook": "https://www.facebook.com/codeforkc",
-            "twitter": "@codeforkc"
-        },
-        "tags": [
-            "Brigade",
-            "Code for America",
-            "midwest",
-            "Official"
         ]
     },
     {
@@ -1252,15 +1282,13 @@
         "city": "Miami, FL",
         "latitude": "25.7890",
         "longitude": "-80.2264",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/CodeForMiami/",
             "twitter": "@codeformiami"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -1409,14 +1437,12 @@
         "city": "Arlington, VA",
         "latitude": "38.8800",
         "longitude": "-77.1068",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@codenovabrigade"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2064,11 +2090,9 @@
         ],
         "projects_list_url": "",
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ],
-        "type": "Brigade, Official, Code for America",
+        "type": "Brigade",
         "rss": "https://google.com/alerts/feeds/06912685966400056337/5865032145652409353"
     },
     {
@@ -2128,15 +2152,13 @@
         "city": "Los Angeles, CA",
         "latitude": "34.0522",
         "longitude": "-118.2437",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/hackforla",
             "twitter": "@hackforLA"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2646,14 +2668,12 @@
         "city": "Lexington, KY",
         "latitude": "38.0406",
         "longitude": "-84.5037",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "twitter": "@openlexington"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ]
     },
     {
@@ -2990,15 +3010,13 @@
         "city": "Milwaukee, WI",
         "latitude": "43.0389",
         "longitude": "-87.9065",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "social_profiles": {
             "facebook": "https://www.facebook.com/mkedata",
             "twitter": "@datamke"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ],
         "rss": "https://google.com/alerts/feeds/06912685966400056337/9762567980029012006"
     },
@@ -3042,16 +3060,14 @@
         "events_url": "",
         "projects_list_url": "github.com/CodeForBerkeley",
         "city": "Berkeley, CA",
-        "type": "Brigade, Official",
+        "type": "Brigade",
         "latitude": "37.8715926",
         "longitude": "-122.272747",
         "social_profiles": {
             "facebook": "https://www.facebook.com/CodeForBerkeley"
         },
         "tags": [
-            "Brigade",
-            "Official",
-            "Code for America"
+            "Brigade"
         ],
         "rss": "https://google.com/alerts/feeds/06912685966400056337/12249826946855578548"
     },


### PR DESCRIPTION
- Remove many Brigades from the map that haven't signed their MOUs
- Add new tags to represent CfA Brigade financial administration types
- Simplify logic for renaming brigades (the new logic fixes a bug where
empty URLs were being treated as equal)
- New Brigades: Code for Hackensack and Code for Kentuckiana