### PR TITLE
Update Code For Tallahassee events URL

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -1861,10 +1861,10 @@
     },
     {
         "name": "Code for Tallahassee",
-        "website": "http://www.codefortallahassee.org/",
-        "events_url": "http://www.codefortallahassee.org/#events",
+        "website": "",
+        "events_url": "https://www.meetup.com/meetup-group-kFdPKltD/",
         "rss": "",
-        "projects_list_url": "https://github.com/codefortallahassee",
+        "projects_list_url": "",
         "city": "Tallahassee, FL",
         "latitude": "30.4380556",
         "longitude": "-84.2808333",

--- a/organizations.json
+++ b/organizations.json
@@ -1862,7 +1862,7 @@
     {
         "name": "Code for Tallahassee",
         "website": "",
-        "events_url": "https://www.meetup.com/meetup-group-kFdPKltD/",
+        "events_url": "https://www.meetup.com/code-for-tallahassee/",
         "rss": "",
         "projects_list_url": "",
         "city": "Tallahassee, FL",


### PR DESCRIPTION
Code For Tallahassee is a new brigade; updated the events URL to point to the new Meetup.com site. 