### PR TITLE
Switch Hack for LA to topic-based projects list

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -816,7 +816,7 @@
         "previous_names": [
             "Hack for LA"
         ],
-        "projects_list_url": "https://github.com/hackforla",
+        "projects_list_url": "https://github.com/topics/hack-for-la",
         "tags": [
             "Brigade",
             "Code for America",


### PR DESCRIPTION
Hack for LA wants to drive their projects list from a topic tag

Does it make sense to merge changes like this into organizations.json, or will that break existing things? Would it make more sense to just fork off the [index's orgs list](https://github.com/codeforamerica/brigade-project-index/tree/cfapi/orgs/v1) instead of continuing to merge it from here?