### PR TITLE
Add tags needed to show up in project index

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -3513,10 +3513,12 @@
         "website": "",
         "projects_list_url": "https://docs.google.com/spreadsheets/d/e/2PACX-1vSRLgFqu8pavGV_3qNZ2MuSbN-DXvk9mD9pR-MbNpNrfwMh_MSVZpAitia_qBrR2jC2KxYruZtMO-I-/pub?gid=0&single=true&output=csv",
         "city": "San Francisco, CA",
-        "type": "Government",
+        "type": "Brigade",
         "tags": [
             "Temporary",
-            "Brigade Collaboration"
+            "Code for America",
+            "Brigade Collaboration",
+            "Brigade"
         ]
     }
 ]


### PR DESCRIPTION
Per the documentation in [this PR to the project index](https://github.com/codeforamerica/brigade-project-index/pull/38/files), tags must include Brigade and Code for America to be included in the project index.