### PR TITLE
Update `hack-for-la` projects_tag and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A single organization's record looks like this:
     "events_url": "http://www.meetup.com/BetaNYC/",
     "rss": "http://betanyc.tumblr.com/",
     "projects_list_url": "http://projects.betanyc.us/projects",
-    "projects_tag": "beta-nyc",
+    "projects_tag": "https://www.github.com/topics/beta-nyc",
     "latitude": "40.7144",
     "longitude": "-74.0060",
     "tags": [
@@ -68,7 +68,7 @@ A single organization's record looks like this:
 * **`rss`** - The URL of a blog or its RSS feed. The API will look in the usual places for a feed URL if the link isn't direct. Non-blog RSS feeds will also be processed.
 * **`previous_names`** - An array of former names of the organization. This can be useful in maintaining URL redirects or noticing which Brigades have changed names over time.
 * **`projects_list_url`** - The URL of a GitHub organization or of a list of project URLs, formatted as [described below](https://github.com/codeforamerica/brigade-information#projects-list).
-* **`projects_tag`** - The GitHub topic tag the Brigade recommends their projects use to associate themselves with the Brigade
+* **`projects_tag`** - The URL of a GitHub topic tag (e.g.: `https://github.com/topics/hack-for-la`) that the Brigade recommends their projects use to associate themselves with the Brigade. Note: A `projects_list_url` will take precedence over this field.
 * **`latitude`** / **`longitude`** - Where your Brigade meets. It can be as specific or general as you want, and can be figured out using a tool like [LatLong.net](http://www.latlong.net/). Required if you want to appear on the [Brigade](http://www.codeforamerica.org/brigade/) or [Code for All](http://codeforall.org/) maps.
 * **`type`** (DEPRECATED) is a list of tags, comma separated. Use `tags` instead.
 * **`social_profiles`** is an object with the keys being the name of the social network and the value being the identifying address on that network. Specifically,

--- a/organizations.json
+++ b/organizations.json
@@ -1351,7 +1351,7 @@
         "previous_names": [
             "Hack for LA"
         ],
-        "projects_tag": "hack-for-la",
+        "projects_tag": "https://www.github.com/topics/hack-for-la",
         "tags": [
             "Brigade",
             "Code for America",
@@ -1372,8 +1372,7 @@
                 "latitude": "34.0536834",
                 "longitude": "-118.2427669"
             }
-        },
-        "projects_list_url": "https://github.com/hackforla"
+        }
     },
     {
         "name": "KC Digital Drive",
@@ -5714,7 +5713,6 @@
         "city": "Bradford, VT",
         "events_url": "https://calendar.google.com/calendar/r?cid=hhk8mes2a4puf2g8a1ujmb91k4@group.calendar.google.com",
         "projects_list_url": "https://github.com/codeforUV",
-        "projects_tag": "code-for-uv",
         "latitude": "43.9926",
         "longitude": "-72.1290",
         "tags": [

--- a/schema.json
+++ b/schema.json
@@ -86,9 +86,9 @@
         "title": "Organization Projects Tag",
         "default": "",
         "examples": [
-          "code-for-atlantis"
+          "https://www.github.com/topics/code-for-atlantis"
         ],
-        "pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
+        "pattern": "^https://www.github.com/topics/([a-zA-Z0-9\\-]+)$"
       },
       "city": {
         "$id": "#/items/properties/city",


### PR DESCRIPTION
The `projects_tag` feature was added so that Brigade leaders could
add a tag to projects in different organizations and have them all
appear on their Brigade's entry in the project index.

There was a discrepancy between this intended behavior and the actual
behavior:
* If `project_list_url` was specified, it would take precedence.
* The topic tag needed specification via full URL in order to match

This commit updates the README and Hack for LA's page to match this
behavior.

cc @themightychris @ExperimentsInHonesty