### PR TITLE
Add tag to Code for America

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -312,7 +312,8 @@
         "latitude": "37.7759",
         "longitude": "-122.4137",
         "tags": [
-            "Code for All"
+            "Code for All",
+            "Code for America"
         ],
         "location": {
             "city": "San Francisco",


### PR DESCRIPTION
The change adds the tag `Code for America` to the organization "Code for America".

The [Brigade Index Statusboard](https://github.com/codeforamerica/brigade-project-index-statusboard) (https://projects.brigade.network/) displays projects whose organization is tagged as either `Brigade` or `Code for America`. At the moment, this doesn't include the organization "Code for America".